### PR TITLE
Fix adding attributes on components

### DIFF
--- a/src/utils/useAttachAttribute.ts
+++ b/src/utils/useAttachAttribute.ts
@@ -6,7 +6,7 @@ export const useAttachAttribute = (
   value: string | boolean | undefined
 ): void => {
   React.useEffect(() => {
-    if (component && value) {
+    if (component && value !== undefined) {
       component.setAttribute(attribute, value.toString());
     }
   }, [component, attribute, value]);


### PR DESCRIPTION
Previously we were checking `&& value` which would cause the attributes not to update on false values. Instead the check should be making sure the value is not undefined