### PR TITLE
Add transactions component and expose attributes methods

### DIFF
--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -27,6 +27,11 @@ export const ConnectNotificationBanner = (): JSX.Element => {
   return wrapper;
 };
 
+export const ConnectTransactions = (): JSX.Element => {
+  const {wrapper} = useCreateComponent('stripe-connect-transactions');
+  return wrapper;
+};
+
 export const ConnectPaymentDetails = ({
   chargeId,
   onClose,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export * from './Components';
 export * from './ConnectComponents';
+export * from './useCreateComponent';
+export * from './utils/useAttachAttribute';
+export * from './utils/useAttachEvent';

--- a/src/useCreateComponent.tsx
+++ b/src/useCreateComponent.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import * as React from 'react';
 import {useConnectComponents} from './ConnectComponents';
+import {ConnectElementTagName} from '@stripe/connect-js';
 
 export const useCreateComponent = (
-  tagName: string
+  tagName: ConnectElementTagName
 ): {wrapper: JSX.Element; component: HTMLElement | null} => {
   const [component, setComponent] = React.useState<HTMLElement | null>(null);
   const {connectInstance} = useConnectComponents();

--- a/src/useCreateComponent.tsx
+++ b/src/useCreateComponent.tsx
@@ -1,10 +1,9 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import * as React from 'react';
-import {ConnectElementTagName} from '@stripe/connect-js';
 import {useConnectComponents} from './ConnectComponents';
 
 export const useCreateComponent = (
-  tagName: ConnectElementTagName
+  tagName: string
 ): {wrapper: JSX.Element; component: HTMLElement | null} => {
   const [component, setComponent] = React.useState<HTMLElement | null>(null);
   const {connectInstance} = useConnectComponents();

--- a/src/utils/useAttachEvent.ts
+++ b/src/utils/useAttachEvent.ts
@@ -8,7 +8,7 @@ export enum ConnectElementEventNames {
 
 export const useAttachEvent = (
   component: HTMLElement | null,
-  eventName: ConnectElementEventNames,
+  eventName: ConnectElementEventNames | string,
   listener: () => void
 ): void => {
   React.useEffect(() => {

--- a/src/utils/useAttachEvent.ts
+++ b/src/utils/useAttachEvent.ts
@@ -8,7 +8,7 @@ export enum ConnectElementEventNames {
 
 export const useAttachEvent = (
   component: HTMLElement | null,
-  eventName: ConnectElementEventNames | string,
+  eventName: ConnectElementEventNames,
   listener: () => void
 ): void => {
   React.useEffect(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext", // Let Babel deal with transpiling new language features
+    "target": "ES6", // Let Babel deal with transpiling new language features
     "module": "esnext",
     "moduleResolution": "node",
     "jsx": "react",


### PR DESCRIPTION
This adds the transactions components. Also exports the methods to add attributes and event listeners to the components. I noticed there would be an issue since the HTML element is not returned directly from the wrappers, so I also exported the `useCreateComponent` method which would allow developers to create an instance of a wrapper and also have access to the html element to add attributes/events to.

Also changes target output to es6.
