### PR TITLE
Accept null or a promise for the ConnectComponentsProvider and only render once the connectInstance is present

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -36,7 +36,7 @@ rules:
   react/forbid-prop-types: 0
   react/no-unused-prop-types: 0
   react-hooks/rules-of-hooks: 2
-  react-hooks/exhaustive-deps: 1
+  react-hooks/exhaustive-deps: 2
   "@typescript-eslint/no-explicit-any": 0
   "@typescript-eslint/no-empty-interface": 0
   "@typescript-eslint/explicit-function-return-type": 0

--- a/examples/components.jsx
+++ b/examples/components.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {loadConnect} from '@stripe/connect-js';
 import {
   ConnectPayments,
@@ -8,15 +7,19 @@ import {
   ConnectComponentsProvider
 } from '@stripe/react-connect-js';
 
-const stripeConnect = await loadConnect();
+const loadConnectJs = async () => {
+  const stripeConnect = await loadConnect();
 
-const connectInstance = stripeConnect.initialize({
-  publishableKey: '{{your publishable key}}',
-  clientSecret: '{{your client secret}}',
-  appearance: {
-    colorPrimary: '#228403', //optional appearance param
-  },
-});
+  return stripeConnect.initialize({
+    publishableKey: '{{your publishable key}}',
+    clientSecret: '{{your client secret}}',
+    appearance: {
+      colorPrimary: '#228403', //optional appearance param
+    },
+  });
+};
+
+const connectInstance = loadConnectJs();
 
 const App = () => {
   return (

--- a/src/ConnectComponents.tsx
+++ b/src/ConnectComponents.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as connectJs from '@stripe/connect-js';
 
 type ConnectComponentsPayload = {
-  connectInstance: connectJs.StripeConnectInstance;
+  connectInstance: connectJs.StripeConnectInstance | null;
 };
 
 const ConnectComponentsContext =
@@ -14,11 +14,25 @@ export const ConnectComponentsProvider = ({
   connectInstance,
   children,
 }: {
-  connectInstance: connectJs.StripeConnectInstance;
+  connectInstance:
+    | Promise<connectJs.StripeConnectInstance>
+    | connectJs.StripeConnectInstance
+    | null;
   children: any;
 }): JSX.Element => {
+  const [resolvedConnectInstance, setResolvedConnectInstance] =
+    React.useState<connectJs.StripeConnectInstance | null>(null);
+
+  React.useEffect(() => {
+    (async () => {
+      setResolvedConnectInstance(await connectInstance);
+    })();
+  }, [connectInstance]);
+
   return (
-    <ConnectComponentsContext.Provider value={{connectInstance}}>
+    <ConnectComponentsContext.Provider
+      value={{connectInstance: resolvedConnectInstance}}
+    >
       {children}
     </ConnectComponentsContext.Provider>
   );

--- a/src/useCreateComponent.tsx
+++ b/src/useCreateComponent.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import * as React from 'react';
 import {useConnectComponents} from './ConnectComponents';
 import {ConnectElementTagName} from '@stripe/connect-js';
@@ -12,14 +11,18 @@ export const useCreateComponent = (
   const wrapper = <div ref={wrapperDivRef}></div>;
 
   React.useLayoutEffect(() => {
-    if (wrapperDivRef.current !== null && component === null) {
+    if (
+      wrapperDivRef.current !== null &&
+      connectInstance &&
+      component === null
+    ) {
       const newComponent = connectInstance.create(tagName);
       setComponent(newComponent);
       if (newComponent !== null) {
         wrapperDivRef.current.replaceChildren(newComponent);
       }
     }
-  }, []);
+  }, [component, connectInstance, tagName]);
 
   return {wrapper, component};
 };


### PR DESCRIPTION
This brings us more inline with react-stripe-js which takes a Promise which is the result of initializing the stripe-js library. We also take a resolved connectInstance or null. This is backwards compatible and flexible enough to support many different initialization patterns. 

This is useful because we have a pattern that stripe-js does not have: namely, allowing multiple initializations of connect-js. 

Both cases will probably have users load the connectJs script at the top level of their app, but depending on whether a consumer also creates a single connectInstance or intends to creates multiple connectInstances will determine whether they need to wait for the promise to resolve at the time that they render the ConnectComponentsProvider.