### PR TITLE
#28 Allow newer version of React.js and beta of `@stripe/connect-js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": "^2.0.1",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "@stripe/connect-js": "^2.0.1 || ^2.0.1-beta.1",
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": "^2.0.1 || ^2.0.1-beta.1",
+    "@stripe/connect-js": ">=2.0.1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }


### PR DESCRIPTION
Hi!

I had the same problem as described in #28. The problem I found is that it only limits to semver of React 16 which is not working with projects that are using React 17 or 18. To solve this I changed the version to be greater than or equal to 16.8.0 (which I think is chosen because this is the first version with hooks). Besides React's version, I'm also using beta connect components which with the current peer dependencies are also not supported, so I propose adding `|| ^2.0.1-beta.1` to solve this problem.

Hope this is helpful and can be merged. Let me know if I can help this PR to be merged and I would be more than happy to make further changes