### PR TITLE
Move stripe-connect-js to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@babel/preset-flow": "7.18.6",
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "2.0.0-beta.1",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -81,7 +80,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": "^1.0.4",
+    "@stripe/connect-js": ">=2.0.0-beta.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   }


### PR DESCRIPTION
Noticed that stripe-connect-js was moved to devdependencies instead of peerdependencies