### PR TITLE
Remove the need for JSON parsing (resolveJsonModules in tsconfig)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/preset-flow": "7.18.6",
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "2.0.1",
+    "@stripe/connect-js": "2.0.3",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -81,7 +81,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=2.0.1",
+    "@stripe/connect-js": ">=2.0.3",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,8 @@ const PLUGINS = [
     extensions: ['.ts', '.js', '.tsx', '.jsx'],
   }),
   replace({
-    _VERSION: JSON.stringify(pkg.version),
+    // This string is replaced by the npm package version when bundling
+    _NPM_PACKAGE_VERSION_: pkg.version,
   }),
   json(),
 ];

--- a/src/useCreateComponent.tsx
+++ b/src/useCreateComponent.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import {version} from '.././package.json';
 import * as React from 'react';
 import {useConnectComponents} from './ConnectComponents';
 import {
@@ -24,9 +23,9 @@ export const useCreateComponent = (
   React.useLayoutEffect(() => {
     if (wrapperDivRef.current !== null && component === null) {
       try {
-        (
-          connectInstance as unknown as IConnectJSWithPrivateMethods
-        ).setReactSdkAnalytics(version);
+        (connectInstance as unknown as IConnectJSWithPrivateMethods)
+          // This will be replaced by the npm package version when bundling
+          .setReactSdkAnalytics('_NPM_PACKAGE_VERSION_');
       } catch (e) {
         console.log('Error setting React Sdk version with error message: ', e);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,10 +1430,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-2.0.1.tgz#a534238de96294822c1d533464f9ed166cbb9377"
-  integrity sha512-Ze5uoQD8NsZQXxl2P3glb5iC9C4isk5pZnYG9Y1+K1IZ23kGCOfd475DPk4uckRiQD6TjGr5P8DdyKwTE9YhNA==
+"@stripe/connect-js@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-2.0.3.tgz#1dd904f62763207ffa4c8ab16fd9ba2368fb05db"
+  integrity sha512-+c0P976SgHjHUjnII4W/UXsC/gmdLgCgldOFPag8hKNGu6rvoZOLOyuHR+JOccmdzmL8tHJGaOvH36WcEli0kA==
   dependencies:
     "@rollup/plugin-json" "^6.0.0"
 


### PR DESCRIPTION
This PR makes use of rollup to get the package.json version in the code, removing the need for parsing the package.json file (which was causing problems for some TS integrations with `resolveJsonModules: false`).

With these updates:
1. The version is included
![image](https://github.com/stripe/react-connect-js/assets/95381655/84dfc43e-3179-40b7-84d9-41e845fc48ca)

2. The package.json file is no longer in shared.ts
