### PR TITLE
Setting a prop to undefined should remove the HTML attribute

### DIFF
--- a/src/utils/useAttachAttribute.ts
+++ b/src/utils/useAttachAttribute.ts
@@ -6,8 +6,13 @@ export const useAttachAttribute = (
   value: string | boolean | undefined
 ): void => {
   React.useEffect(() => {
-    if (component && value !== undefined) {
+    if (!component) return;
+
+    if (value !== undefined) {
       component.setAttribute(attribute, value.toString());
+    } else {
+      // RemoveAttribute is a no-op if the attribute is not present
+      component.removeAttribute(attribute);
     }
   }, [component, attribute, value]);
 };


### PR DESCRIPTION
Today the react SDK is never removing HTML attributes, even when setting a prop to `undefined`. This can be a problem when explicitly setting a prop to `undefined` - this PR fixes it by calling `removeAttribute` when the prop is set to undefined.


https://github.com/stripe/react-connect-js/assets/95381655/4239fbcc-0862-4619-8e4d-7846b1b3e7c4

