### PR TITLE
Add ConnectPaymentMethodSettings component for beta access

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/preset-flow": "7.18.6",
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "2.0.1-beta.4",
+    "@stripe/connect-js": "2.0.1-beta.5",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -81,7 +81,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=2.0.1-beta.4",
+    "@stripe/connect-js": ">=2.0.1-beta.5",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -59,7 +59,7 @@ export const ConnectAccountOnboarding = ({
   );
 
   useAttachAttribute(onboarding, 'privacy-policy-url', privacyPolicyUrl);
-  
+
   useAttachAttribute(
     onboarding,
     'skip-terms-of-service-collection',
@@ -68,5 +68,10 @@ export const ConnectAccountOnboarding = ({
 
   useAttachEvent(onboarding, ConnectElementEventNames.exit, onExit);
 
+  return wrapper;
+};
+
+export const ConnectPaymentMethodSettings = (): JSX.Element => {
+  const {wrapper} = useCreateComponent('payment-method-settings');
   return wrapper;
 };


### PR DESCRIPTION
~Depends on https://github.com/stripe/connect-js/pull/51.~ 

This adds the ConnectPaymentMethodSettings component (currently in private beta). I also updated the package dependencies to require `"@stripe/connect-js": "2.0.1-beta.5"` which adds the underlying enum value.