### PR TITLE
Add Issuing Card and Issuing Cards List wrappers

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=2.0.1-beta.7",
+    "@stripe/connect-js": ">=3.1.0-beta.1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -91,3 +91,62 @@ export const ConnectNotificationBanner = (): JSX.Element => {
   const {wrapper} = useCreateComponent('notification-banner');
   return wrapper;
 };
+
+export const ConnectIssuingCard = ({
+  defaultCard,
+  cardArtFileLink,
+  cardSwitching,
+  fetchEphemeralKey,
+}: {
+  defaultCard?: string;
+  cardArtFileLink?: string;
+  cardSwitching?: boolean;
+  fetchEphemeralKey?: (fetchParams: {
+    nonce: string;
+    issuingCard: string;
+  }) => Promise<{
+    ephemeralKeySecret: string;
+    nonce: string;
+    issuingCard: string;
+  }>;
+}): JSX.Element => {
+  const {wrapper, component: issuingCard} = useCreateComponent('issuing-card');
+
+  React.useEffect(() => {
+    if (!issuingCard) return;
+    issuingCard.setDefaultCard(defaultCard);
+    issuingCard.setCardArtFileLink(cardArtFileLink);
+    issuingCard.setCardSwitching(cardSwitching);
+    issuingCard.setFetchEphemeralKey(fetchEphemeralKey);
+  }, [
+    issuingCard,
+    defaultCard,
+    cardArtFileLink,
+    cardSwitching,
+    fetchEphemeralKey,
+  ]);
+
+  return wrapper;
+};
+
+export const ConnectIssuingCardsList = ({
+  fetchEphemeralKey,
+}: {
+  fetchEphemeralKey?: (fetchParams: {
+    nonce: string;
+    issuingCard: string;
+  }) => Promise<{
+    ephemeralKeySecret: string;
+    nonce: string;
+    issuingCard: string;
+  }>;
+}): JSX.Element => {
+  const {wrapper, component: issuingCardsList} =
+    useCreateComponent('issuing-cards-list');
+
+  React.useEffect(() => {
+    if (!issuingCardsList) return;
+    issuingCardsList.setFetchEphemeralKey(fetchEphemeralKey);
+  }, [issuingCardsList, fetchEphemeralKey]);
+  return wrapper;
+};

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {useCreateComponent} from './useCreateComponent';
 import {useAttachAttribute} from './utils/useAttachAttribute';
+import {useUpdateWithSetter} from './utils/useUpdateWithSetter';
 
 export const ConnectPayments = (): JSX.Element => {
   const {wrapper} = useCreateComponent('payments');
@@ -53,21 +54,19 @@ export const ConnectAccountOnboarding = ({
   const {wrapper, component: onboarding} =
     useCreateComponent('account-onboarding');
 
-  React.useEffect(() => {
-    if (!onboarding) return;
-    onboarding.setRecipientTermsOfServiceUrl(recipientTermsOfServiceUrl);
-    onboarding.setFullTermsOfServiceUrl(fullTermsOfServiceUrl);
-    onboarding.setPrivacyPolicyUrl(privacyPolicyUrl);
-    onboarding.setSkipTermsOfServiceCollection(skipTermsOfServiceCollection);
-    onboarding.setOnExit(onExit);
-  }, [
-    fullTermsOfServiceUrl,
-    onExit,
-    onboarding,
-    privacyPolicyUrl,
-    recipientTermsOfServiceUrl,
-    skipTermsOfServiceCollection,
-  ]);
+  useUpdateWithSetter(onboarding, recipientTermsOfServiceUrl, (comp, val) =>
+    comp.setRecipientTermsOfServiceUrl(val)
+  );
+  useUpdateWithSetter(onboarding, fullTermsOfServiceUrl, (comp, val) =>
+    comp.setFullTermsOfServiceUrl(val)
+  );
+  useUpdateWithSetter(onboarding, privacyPolicyUrl, (comp, val) =>
+    comp.setPrivacyPolicyUrl(val)
+  );
+  useUpdateWithSetter(onboarding, skipTermsOfServiceCollection, (comp, val) =>
+    comp.setSkipTermsOfServiceCollection(val)
+  );
+  useUpdateWithSetter(onboarding, onExit, (comp, val) => comp.setOnExit(val));
 
   return wrapper;
 };
@@ -96,57 +95,37 @@ export const ConnectIssuingCard = ({
   defaultCard,
   cardArtFileLink,
   cardSwitching,
-  fetchEphemeralKey,
 }: {
   defaultCard?: string;
   cardArtFileLink?: string;
   cardSwitching?: boolean;
-  fetchEphemeralKey?: (fetchParams: {
-    nonce: string;
-    issuingCard: string;
-  }) => Promise<{
-    ephemeralKeySecret: string;
-    nonce: string;
-    issuingCard: string;
-  }>;
 }): JSX.Element => {
   const {wrapper, component: issuingCard} = useCreateComponent('issuing-card');
 
-  React.useEffect(() => {
-    if (!issuingCard) return;
-    issuingCard.setDefaultCard(defaultCard);
-    issuingCard.setCardArtFileLink(cardArtFileLink);
-    issuingCard.setCardSwitching(cardSwitching);
-    issuingCard.setFetchEphemeralKey(fetchEphemeralKey);
-  }, [
-    issuingCard,
-    defaultCard,
-    cardArtFileLink,
-    cardSwitching,
-    fetchEphemeralKey,
-  ]);
+  useUpdateWithSetter(issuingCard, defaultCard, (comp, val) =>
+    comp.setDefaultCard(val)
+  );
+  useUpdateWithSetter(issuingCard, cardArtFileLink, (comp, val) =>
+    comp.setCardArtFileLink(val)
+  );
+  useUpdateWithSetter(issuingCard, cardSwitching, (comp, val) =>
+    comp.setCardSwitching(val)
+  );
 
   return wrapper;
 };
 
 export const ConnectIssuingCardsList = ({
-  fetchEphemeralKey,
+  cardArtFileLink,
 }: {
-  fetchEphemeralKey?: (fetchParams: {
-    nonce: string;
-    issuingCard: string;
-  }) => Promise<{
-    ephemeralKeySecret: string;
-    nonce: string;
-    issuingCard: string;
-  }>;
+  cardArtFileLink?: string;
 }): JSX.Element => {
   const {wrapper, component: issuingCardsList} =
     useCreateComponent('issuing-cards-list');
 
-  React.useEffect(() => {
-    if (!issuingCardsList) return;
-    issuingCardsList.setFetchEphemeralKey(fetchEphemeralKey);
-  }, [issuingCardsList, fetchEphemeralKey]);
+  useUpdateWithSetter(issuingCardsList, cardArtFileLink, (comp, val) =>
+    comp.setCardArtFileLink(val)
+  );
+
   return wrapper;
 };

--- a/src/utils/useUpdateWithSetter.ts
+++ b/src/utils/useUpdateWithSetter.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export const useUpdateWithSetter = <
+  T extends HTMLElement,
+  V extends string | boolean | (() => void) | undefined
+>(
+  component: T | null,
+  value: V,
+  onUpdated: (component: T, value: V) => void
+): void => {
+  React.useEffect(() => {
+    if (!component) return;
+    onUpdated(component, value);
+  }, [component, value, onUpdated]);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,10 +1430,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@2.0.1-beta.7":
-  version "2.0.1-beta.7"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-2.0.1-beta.7.tgz#efa2d73c66d8ffb306b057f84f71f9c84488cc5d"
-  integrity sha512-c0MED84WJydlTwILsYBeQ1y5ApwNQpoIELZbLInEj2UN2BwPr14MAwoGcmtAIsYRWCfgy0RkLljzn2lqaLkVTA==
+"@stripe/connect-js@3.1.0-beta.1":
+  version "3.1.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.1.0-beta.1.tgz#1a25bad08d0939e2083615996eecdd18da35fc60"
+  integrity sha512-zJnJdG1O/PTv0k70a2o53WRtNxbW2/mh+/uOGm7zY6Oy5AJ1+521Ud1cgNZsxn///uUDSkHyVHGnH/tENpV75g==
   dependencies:
     "@rollup/plugin-json" "^6.0.0"
 


### PR DESCRIPTION
Adds support for Issuing Card and Issuing Cards List plus setter methods. 

Also implements `useUpdateWithSetter` that's also going into `master` in #52. 