### PR TITLE
Adds collectionOptions to ConnectAccountOnboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/preset-flow": "7.18.6",
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.2.0",
+    "@stripe/connect-js": "3.3.0",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -33,18 +33,25 @@ export const ConnectPaymentDetails = ({
   return wrapper;
 };
 
+export type CollectionOptions = {
+  fields: "currently_due" | "eventually_due";
+  futureRequirements?: "omit" | "include";
+}
+
 export const ConnectAccountOnboarding = ({
   onExit,
   recipientTermsOfServiceUrl,
   fullTermsOfServiceUrl,
   privacyPolicyUrl,
   skipTermsOfServiceCollection,
+  collectionOptions,
 }: {
   onExit: () => void;
   recipientTermsOfServiceUrl?: string;
   fullTermsOfServiceUrl?: string;
   privacyPolicyUrl?: string;
   skipTermsOfServiceCollection?: boolean;
+  collectionOptions?: CollectionOptions;
 }): JSX.Element | null => {
   const {wrapper, component: onboarding} =
     useCreateComponent('account-onboarding');
@@ -60,6 +67,9 @@ export const ConnectAccountOnboarding = ({
   );
   useUpdateWithSetter(onboarding, skipTermsOfServiceCollection, (comp, val) =>
     comp.setSkipTermsOfServiceCollection(val)
+  );
+  useUpdateWithSetter(onboarding, collectionOptions, (comp, val) =>
+    comp.setCollectionOptions(val)
   );
   useUpdateWithSetter(onboarding, onExit, (comp, val) => comp.setOnExit(val));
 

--- a/src/utils/useUpdateWithSetter.ts
+++ b/src/utils/useUpdateWithSetter.ts
@@ -1,8 +1,9 @@
 import React from 'react';
+import { CollectionOptions } from '../Components';
 
 export const useUpdateWithSetter = <
   T extends HTMLElement,
-  V extends string | boolean | (() => void) | undefined
+  V extends string | boolean | (() => void) | CollectionOptions | undefined
 >(
   component: T | null,
   value: V,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,10 +1430,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.2.0.tgz#3c9a18be05d1b81bab251843e341ccd0d376d161"
-  integrity sha512-Wpetqb/FsEoyQlDBxpEGvOMzvCmiV0IAw5yb7AFLisq1DrISxTOOZBMuOXkpABMF/UUymluBWrULw9695V1H5A==
+"@stripe/connect-js@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.0.tgz#e793e19cc48cc59a777f97348e9020bde3f70fa5"
+  integrity sha512-94u7QVt3UfIRksUOQka4ecUOtz2DxqUrBNf2KxlJUWHmNGd1awTGtAFqt09RpihpsPQUvZdGHshemPYTJSiMkQ==
   dependencies:
     "@rollup/plugin-json" "^6.0.0"
 


### PR DESCRIPTION
Adds `collectionOptions` to support collecting future requirements using the API aligned on:

```
collectionOptions?: {
  fields: 'currently_due' | 'eventually_due',
  futureRequirements?: 'omit' | 'include' // Default to `omit`
}
```