### PR TITLE
Require an updated verison of connect-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.2.0",
+    "@stripe/connect-js": ">=3.3.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }


### PR DESCRIPTION
A previous PR https://github.com/stripe/react-connect-js/pull/61 did not bump the `devDependencies`, so fixing that here