### PR TITLE
Require higher beta version of connect.js in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.2.2-beta-1",
+    "@stripe/connect-js": ">=3.3.0-beta-1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }


### PR DESCRIPTION
A previous PR https://github.com/stripe/react-connect-js/pull/63 missed a devDependencies update, so fixing that here