### PR TITLE
Expose the useUpdateWithSetter utility for consumers to use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './ConnectComponents';
 export * from './useCreateComponent';
 export * from './utils/useAttachAttribute';
 export * from './utils/useAttachEvent';
+export * from './utils/useUpdateWithSetter';


### PR DESCRIPTION
Consumers aren't able to use the `useUpdateWithSetter` utility hook, this exports it so that it is available.