### PR TITLE
[Beta] Remove visible prop and update example code/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ const App = () => (
       onClose={() => {
         console.log('closed');
       }}
-      chargeId="pi_test123"
-      visible
+      payment="pi_test123"
     />
   </ConnectComponentsProvider>
 );

--- a/examples/components.jsx
+++ b/examples/components.jsx
@@ -1,21 +1,24 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {loadConnect} from '@stripe/connect-js';
 import {
   ConnectPayments,
   ConnectPayouts,
   ConnectPaymentDetails,
-  ConnectComponentsProvider
+  ConnectComponentsProvider,
+  loadConnectAndInitialize
 } from '@stripe/react-connect-js';
 
-const stripeConnect = await loadConnect();
-
-const connectInstance = stripeConnect.initialize({
+const fetchClientSecret = async () => {
+  // Fetch the AccountSession client secret by making an API call to your service
+};
+const connectInstance = loadConnectAndInitialize({
   publishableKey: '{{your publishable key}}',
-  clientSecret: '{{your client secret}}',
+  fetchClientSecret: fetchClientSecret,
   appearance: {
-    colorPrimary: '#228403', //optional appearance param
-  },
+    variables: {
+      colorPrimary: '#228403', //optional appearance param,
+    },
+  }
 });
 
 const App = () => {
@@ -27,8 +30,7 @@ const App = () => {
         onClose={() => {
           console.log('closed');
         }}
-        chargeId="pi_test123"
-        visible
+        payment="pi_test123"
       />
     </ConnectComponentsProvider>
   );

--- a/examples/components.jsx
+++ b/examples/components.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {
   ConnectPayments,
   ConnectPayouts,

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {useCreateComponent} from './useCreateComponent';
 import {useUpdateWithSetter} from './utils/useUpdateWithSetter';
 import {CollectionOptions, FetchEphemeralKeyFunction} from './types';

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {useCreateComponent} from './useCreateComponent';
-import {useAttachAttribute} from './utils/useAttachAttribute';
 import {useUpdateWithSetter} from './utils/useUpdateWithSetter';
 import {CollectionOptions, FetchEphemeralKeyFunction} from './types';
 
@@ -16,26 +15,23 @@ export const ConnectPayouts = (): JSX.Element => {
 
 export const ConnectPaymentDetails = ({
   payment,
-  onClose,
-  visible = undefined,
+  onClose
 }: {
   /**
    * @param payment the ID of `payment`, `charge`, or `paymentIntent` to be displayed.
    */
   payment: string;
   onClose: () => void;
-  visible?: boolean | undefined;
 }): JSX.Element | null => {
   const {wrapper, component: paymentDetails} =
     useCreateComponent('payment-details');
 
-  useAttachAttribute(paymentDetails, 'visible', visible);
-  React.useEffect(() => {
-    if (!paymentDetails) return;
-    paymentDetails.setPayment(payment);
-    paymentDetails.setOnClose(onClose);
-  }, [paymentDetails, payment, onClose]);
-
+  useUpdateWithSetter(paymentDetails, payment, (comp, val) =>
+    comp.setPayment(val)
+  );
+  useUpdateWithSetter(paymentDetails, onClose, (comp, val) =>
+    comp.setOnClose(val)
+  );
   return wrapper;
 };
 


### PR DESCRIPTION
### Summary
- Removes `visible` prop from PaymentDetails component that is no longer supported, from the README and the example code
- Changes `chargeId` prop in PaymentDetails component to use `payments`
- Updates example code to use `loadConnectAndInitialize`