### PR TITLE
Set the width of the wrapper div to 100% to preserve the "full width" expectation of embedded components

### DIFF
--- a/src/useCreateComponent.tsx
+++ b/src/useCreateComponent.tsx
@@ -14,11 +14,16 @@ export const useCreateComponent = <T extends ConnectElementTagName>(
   >(null);
   const {connectInstance} = useConnectComponents();
   const wrapperDivRef = React.useRef<HTMLDivElement | null>(null);
-  const wrapper = <div ref={wrapperDivRef}></div>;
+
+  // We set width to 100% to preserve this functionality aspect of embedded components even though
+  // we are introducing a wrapper div for this element
+  // https://docs.corp.stripe.com/connect/get-started-connect-embedded-components#width-and-height
+  const wrapper = <div style={{width: '100%'}} ref={wrapperDivRef}></div>;
 
   React.useLayoutEffect(() => {
     if (wrapperDivRef.current !== null && component === null) {
       const newComponent = connectInstance.create(tagName);
+
       setComponent(newComponent);
       if (newComponent !== null) {
         try {


### PR DESCRIPTION
Connect embedded components advertise they would take the full width of the page: https://docs.corp.stripe.com/connect/get-started-connect-embedded-components#width-and-height. However this isn't always true, specifically if you do:

```
<style>
.content {
    display: flex;
    justify-content: center;
    align-items: center;
    flex-direction: column;
    text-align: center;
    width: 420px;
    padding-top: 40px;
    margin-bottom: 110px;
}
</style>
<div class="content">
  <ConnectOnboarding />
</div>
```

The width of ConnectOnboarding would be as small as possible (320px!).

This breaks the advertised 100% width promise, and results in a very narrow UI:
![image](https://github.com/stripe/react-connect-js/assets/95381655/3255a4fd-e083-4696-bbed-3060621a561f)

This also repro's for other components:
![image](https://github.com/stripe/react-connect-js/assets/95381655/30cea2d4-172d-47ce-9a2c-b84b5e7942cc)

With this fix, the wrapper div takes the full width, allowing the custom element to also take the full width:

Onboarding:
![image](https://github.com/stripe/react-connect-js/assets/95381655/f0eb4e1b-8ea4-4609-92f2-6db1599ac8b6)

Payments:
![image](https://github.com/stripe/react-connect-js/assets/95381655/0fed4fe1-5335-4e71-bfea-218fafc7b603)

Some more testing with components and other style configurations:

https://github.com/stripe/react-connect-js/assets/95381655/deebefc8-6fa6-4adc-9a3e-2956e643caca


