### PR TITLE
Add paymentMethodConfiguration property to the ConnectPaymentMethodSettings component

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.3.14-beta-1",
+    "@stripe/connect-js": "3.3.15-beta-1",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -84,7 +84,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.3.13-beta-1",
+    "@stripe/connect-js": ">=3.3.15-beta-1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -207,11 +207,20 @@ export const ConnectAccountOnboarding = ({
 };
 
 export const ConnectPaymentMethodSettings = ({
+  paymentMethodConfiguration,
   onLoadError,
   onLoaderStart,
-}: CommonComponentProps): JSX.Element => {
+}: {
+  paymentMethodConfiguration?: string;
+} & CommonComponentProps): JSX.Element => {
   const {wrapper, component: paymentMethodSettings} = useCreateComponent(
     'payment-method-settings'
+  );
+
+  useUpdateWithSetter(
+    paymentMethodSettings,
+    paymentMethodConfiguration,
+    (comp, val) => comp.setPaymentMethodConfiguration(val)
   );
 
   useUpdateWithSetter(paymentMethodSettings, onLoaderStart, (comp, val) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,10 +1454,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.3.14-beta-1":
-  version "3.3.14-beta-1"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.14-beta-1.tgz#009d254fed2209779ff595d5618a344dfe8e0e79"
-  integrity sha512-RYy3idMTSACWFe2NxJhrytAARsMTJZz5CrLREMXO4MKSb29awpQdcEHGG2N7Qg2LuoomAwJ9eJESvz2YiZLN2w==
+"@stripe/connect-js@3.3.15-beta-1":
+  version "3.3.15-beta-1"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.15-beta-1.tgz#6b9f1e2f28dc6d7de5266cea9e51669a88084d72"
+  integrity sha512-kGmShz5Vdh016AELGcJkYXViErd5ULGAcpZ7wJ7N3sAEmHEPFV2dlyCWmnO3RFzWb6su1K4gzZ3BeC525xzqKw==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
Added to ConnectJS here: https://github.com/stripe/connect-js/pull/145

It's only blocked by needing a new connect-js `beta` release to be cut. In this PR, I've optimistically updated the package.json to use the anticipated next version of `connect-js@beta` once it's released.