### PR TITLE
Make onLoaderStart and onLoadError optional

### DIFF
--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -3,8 +3,8 @@ import {useUpdateWithSetter} from './utils/useUpdateWithSetter';
 import {LoadError, LoaderStart, NotificationCount} from '@stripe/connect-js';
 
 export type CommonComponentProps = {
-  onLoaderStart: ({elementTagName}: LoaderStart) => void;
-  onLoadError: ({error, elementTagName}: LoadError) => void;
+  onLoaderStart?: ({elementTagName}: LoaderStart) => void;
+  onLoadError?: ({error, elementTagName}: LoadError) => void;
 };
 
 export const ConnectPayments = ({


### PR DESCRIPTION
Fixes https://github.com/stripe/react-connect-js/issues/107

Before:
![image](https://github.com/user-attachments/assets/acce1bc2-2557-4b88-96c3-6c20fad91c26)


After:
![image](https://github.com/user-attachments/assets/f7be3ef7-7a81-4e38-b043-e2bf61731b3a)
