### PR TITLE
Remove card art file link setters from Issuing ECs

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.3.15-beta-1",
+    "@stripe/connect-js": "3.3.16-beta-1",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -84,7 +84,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.3.15-beta-1",
+    "@stripe/connect-js": ">=3.3.16-beta-1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -303,14 +303,12 @@ export const ConnectNotificationBanner = ({
 
 export const ConnectIssuingCard = ({
   defaultCard,
-  cardArtFileLink,
   cardSwitching,
   fetchEphemeralKey,
   onLoadError,
   onLoaderStart,
 }: {
   defaultCard?: string;
-  cardArtFileLink?: string;
   cardSwitching?: boolean;
   fetchEphemeralKey?: FetchEphemeralKeyFunction;
 } & CommonComponentProps): JSX.Element => {
@@ -318,9 +316,6 @@ export const ConnectIssuingCard = ({
 
   useUpdateWithSetter(issuingCard, defaultCard, (comp, val) =>
     comp.setDefaultCard(val)
-  );
-  useUpdateWithSetter(issuingCard, cardArtFileLink, (comp, val) =>
-    comp.setCardArtFileLink(val)
   );
   useUpdateWithSetter(issuingCard, cardSwitching, (comp, val) =>
     comp.setCardSwitching(val)
@@ -339,20 +334,15 @@ export const ConnectIssuingCard = ({
 };
 
 export const ConnectIssuingCardsList = ({
-  cardArtFileLink,
   fetchEphemeralKey,
   onLoadError,
   onLoaderStart,
 }: {
-  cardArtFileLink?: string;
   fetchEphemeralKey?: FetchEphemeralKeyFunction;
 } & CommonComponentProps): JSX.Element => {
   const {wrapper, component: issuingCardsList} =
     useCreateComponent('issuing-cards-list');
 
-  useUpdateWithSetter(issuingCardsList, cardArtFileLink, (comp, val) =>
-    comp.setCardArtFileLink(val)
-  );
   useUpdateWithSetter(issuingCardsList, fetchEphemeralKey, (comp, val) =>
     comp.setFetchEphemeralKey(val)
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,10 +1454,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.3.15-beta-1":
-  version "3.3.15-beta-1"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.15-beta-1.tgz#6b9f1e2f28dc6d7de5266cea9e51669a88084d72"
-  integrity sha512-kGmShz5Vdh016AELGcJkYXViErd5ULGAcpZ7wJ7N3sAEmHEPFV2dlyCWmnO3RFzWb6su1K4gzZ3BeC525xzqKw==
+"@stripe/connect-js@3.3.16-beta-1":
+  version "3.3.16-beta-1"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.16-beta-1.tgz#b529366fb85694d9d972d98e23fac6e1c2036809"
+  integrity sha512-SI3lx7W5GRVOZQbk3Lmy7MW6gkeAFV4YmIp2T3DtmHy/uzy8S6PdYqMdEazI+/EE08hLctrGEEsWAx03R5LF3g==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
We'll be removing the card art file link setters, so we need to update the React wrappers appropriately. Updated the package.json file to the latest connect-js beta version that includes https://github.com/stripe/connect-js/pull/156 and the yarn.lock file.