### PR TITLE
Add showSpendControls prop to the IssuingCard and IssuingCardsList components

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.3.18-preview-1",
+    "@stripe/connect-js": "3.3.19-preview-1",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -84,7 +84,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.3.18-preview-1",
+    "@stripe/connect-js": ">=3.3.19-preview-1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -350,15 +350,20 @@ export const ConnectIssuingCard = ({
 };
 
 export const ConnectIssuingCardsList = ({
+  showSpendControls,
   fetchEphemeralKey,
   onLoadError,
   onLoaderStart,
 }: {
+  showSpendControls?: boolean;
   fetchEphemeralKey?: FetchEphemeralKeyFunction;
 } & CommonComponentProps): JSX.Element => {
   const {wrapper, component: issuingCardsList} =
     useCreateComponent('issuing-cards-list');
 
+  useUpdateWithSetter(issuingCardsList, showSpendControls, (comp, val) =>
+    comp.setShowSpendControls(val)
+  );
   useUpdateWithSetter(issuingCardsList, fetchEphemeralKey, (comp, val) =>
     comp.setFetchEphemeralKey(val)
   );

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -315,12 +315,14 @@ export const ConnectNotificationBanner = ({
 export const ConnectIssuingCard = ({
   defaultCard,
   cardSwitching,
+  showSpendControls,
   fetchEphemeralKey,
   onLoadError,
   onLoaderStart,
 }: {
   defaultCard?: string;
   cardSwitching?: boolean;
+  showSpendControls?: boolean;
   fetchEphemeralKey?: FetchEphemeralKeyFunction;
 } & CommonComponentProps): JSX.Element => {
   const {wrapper, component: issuingCard} = useCreateComponent('issuing-card');
@@ -330,6 +332,9 @@ export const ConnectIssuingCard = ({
   );
   useUpdateWithSetter(issuingCard, cardSwitching, (comp, val) =>
     comp.setCardSwitching(val)
+  );
+  useUpdateWithSetter(issuingCard, showSpendControls, (comp, val) =>
+    comp.setShowSpendControls(val)
   );
   useUpdateWithSetter(issuingCard, fetchEphemeralKey, (comp, val) =>
     comp.setFetchEphemeralKey(val)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,10 +1454,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.3.18-preview-1":
-  version "3.3.18-preview-1"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.18-preview-1.tgz#aab1cd46fa4b8e35d68f7bf6fa50e411302e0f4c"
-  integrity sha512-j26EGOKZ8RIunh6QY+vq+asGxP/TjxLryRvnUNaeWQmDfK0kr6t7Vx2wj7lm6yNBVCAfIxtNSRfnTDGpkq0heQ==
+"@stripe/connect-js@3.3.19-preview-1":
+  version "3.3.19-preview-1"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.19-preview-1.tgz#7fb13d5d1bc22aac4c4837230277ab31f09308a3"
+  integrity sha512-DYepnrlInmnpZ6wOQp+c8/fxT5DUpQxFZvqpZY2QjIbc2RIXQYU+cyTr2HwSy3x2NXrhi28x2GGLtDQlxVWR7g==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
This adds the showSpendControls to the IssuingCard and IssuingCardsList components and bumps the connect-js dependency version to the latest that includes the changes from https://github.com/stripe/connect-js/pull/162.