### PR TITLE
Rename CapitalFinancing faqUrl parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.3.20-preview-1",
+    "@stripe/connect-js": "3.3.21-preview-1",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -84,7 +84,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.3.20-preview-1",
+    "@stripe/connect-js": ">=3.3.21-preview-1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -457,7 +457,7 @@ export const ConnectCapitalOverview = ({
 export const ConnectCapitalFinancing = ({
   defaultFinancingOffer,
   showFinancingSelector,
-  faqUrl,
+  howCapitalWorksUrl,
   supportUrl,
   onFinancingsLoaded,
   onLoadError,
@@ -465,7 +465,7 @@ export const ConnectCapitalFinancing = ({
 }: {
   defaultFinancingOffer?: string;
   showFinancingSelector?: boolean;
-  faqUrl?: string;
+  howCapitalWorksUrl?: string;
   supportUrl?: string;
   onFinancingsLoaded?: ({total}: {total: number}) => void;
 } & CommonComponentProps): JSX.Element => {
@@ -480,8 +480,8 @@ export const ConnectCapitalFinancing = ({
     comp.setShowFinancingSelector(val)
   );
 
-  useUpdateWithSetter(capitalFinancing, faqUrl, (comp, val) =>
-    comp.setFaqUrl(val)
+  useUpdateWithSetter(capitalFinancing, howCapitalWorksUrl, (comp, val) =>
+    comp.setHowCapitalWorksUrl(val)
   );
 
   useUpdateWithSetter(capitalFinancing, supportUrl, (comp, val) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,10 +1454,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.3.20-preview-1":
-  version "3.3.20-preview-1"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.20-preview-1.tgz#2e18a3da468746950378d8081473cc66eccdbc1c"
-  integrity sha512-rxjKzQkYXIsIboOflxDDpAbanIqgi7GoS2J3CjRyqB4u2fcsFyJDI/Rpr5cXXJ/YKr+ssUOnBv2X8iMlRPPg9A==
+"@stripe/connect-js@3.3.21-preview-1":
+  version "3.3.21-preview-1"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.21-preview-1.tgz#2b3023cc8c7b496454b9d58c4b3aa602b32ce19e"
+  integrity sha512-pBEL6XSkjub9fPC99lhWwxWeSabShHegDslVna1FJR1tmxU4yJl8zV/0THaX/Eu/19IIFQs+zt8Ya/jYz3Uiug==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
Follow up to https://github.com/stripe/connect-js/pull/182

Renames the `faqUrl` parameter to `howCapitalWorksUrl` to be consistent with the other Capital components per the latest [API review addendum](https://docs.google.com/document/d/1UOfEiV031A8ml3dJJNaHjdZs3PAMp0B0zCmgj4Hk2P0/edit?tab=t.0#bookmark=id.bwp66tafe1n3)

Note that this is a _breaking_ change but the component is not used by any external platforms