### PR TITLE
Update useUpdateWithSetter to not cause a react render loop when the setter fails

### DIFF
--- a/src/utils/useUpdateWithSetter.ts
+++ b/src/utils/useUpdateWithSetter.ts
@@ -36,6 +36,12 @@ export const useUpdateWithSetter = <
 ): void => {
   React.useEffect(() => {
     if (!component) return;
-    onUpdated(component, value);
+
+    try {
+      onUpdated(component, value);
+    } catch (error) {
+      console.error('Error when calling setter! ', error);
+      return;
+    }
   }, [component, value, onUpdated]);
 };


### PR DESCRIPTION
A setter can fail on invalid values, and it can also fail when it is not defined. We want to avoid causing the entire react tree to fail rendering.