### PR TITLE
Add default filters setter and update connect.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.3.22-preview-1",
+    "@stripe/connect-js": "3.3.22-preview-2",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -84,7 +84,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.3.21-preview-1",
+    "@stripe/connect-js": ">=3.3.21-preview-2",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -15,6 +15,7 @@ import {
   IntervalType,
   ReportName,
   RecipientDataSource,
+  PaymentsListDefaultFilters
 } from '@stripe/connect-js';
 
 export type CommonComponentProps = {
@@ -92,9 +93,10 @@ export const ConnectBalances = ({
 };
 
 export const ConnectPayments = ({
+  defaultFilters,
   onLoadError,
   onLoaderStart,
-}: CommonComponentProps): JSX.Element => {
+}: {defaultFilters?: PaymentsListDefaultFilters} & CommonComponentProps): JSX.Element => {
   const {wrapper, component: payments} = useCreateComponent('payments');
 
   useUpdateWithSetter(payments, onLoaderStart, (comp, val) => {
@@ -102,6 +104,9 @@ export const ConnectPayments = ({
   });
   useUpdateWithSetter(payments, onLoadError, (comp, val) => {
     comp.setOnLoadError(val);
+  });
+  useUpdateWithSetter(payments, defaultFilters, (comp, val) => {
+    comp.setDefaultFilters(val);
   });
 
   return wrapper;

--- a/src/utils/useUpdateWithSetter.ts
+++ b/src/utils/useUpdateWithSetter.ts
@@ -10,6 +10,7 @@ import {
   InstallState,
   NotificationCount,
   StepChange,
+  PaymentsListDefaultFilters,
 } from '@stripe/connect-js';
 
 export const useUpdateWithSetter = <
@@ -22,6 +23,7 @@ export const useUpdateWithSetter = <
     | (() => void)
     | FetchEphemeralKeyFunction
     | CollectionOptions
+    | PaymentsListDefaultFilters
     | ((notificationCount: NotificationCount) => void)
     | ((loaderStart: LoaderStart) => void)
     | ((loaderError: LoadError) => void)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,10 +1454,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.3.22-preview-1":
-  version "3.3.22-preview-1"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.22-preview-1.tgz#b94b0c8eac058f370e5bf47901e758a514afa34b"
-  integrity sha512-aWlczAF4buip9snjImtWIbgwhto+xRefBxDpDX6SAg1klgc8Kmvcby8MPN9Qmc37dZRFjnlvtd2EXDbcX0omzw==
+"@stripe/connect-js@3.3.22-preview-2":
+  version "3.3.22-preview-2"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.22-preview-2.tgz#0a2a260ebc32586f3290e56299a602ad198fc42f"
+  integrity sha512-KYHRwInYRXklXwQZmu3YVhN3xlpBscZw1Fyhgz1+Zs8uORYNkt2BJr09GQabR9PpEktLttv0HaILMS1aks0gOQ==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
Same changes as #135. Add `setDefaultFilters` setter and related types to Payments component, and update the connect.js version.