### PR TITLE
Add activeFinancingCount to setOnEligibleFinancingOfferLoaded payload in CapitalFinancingPromotion component

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.3.22-preview-2",
+    "@stripe/connect-js": "3.3.23-preview-1",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -85,7 +85,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.3.22-preview-2",
+    "@stripe/connect-js": ">=3.3.23-preview-1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -594,6 +594,7 @@ export const ConnectCapitalFinancingPromotion = ({
   layout?: FinancingPromotionLayoutType;
   onEligibleFinancingOfferLoaded?: ({
     productType,
+    activeFinancingCount,
   }: FinancingProductType) => void;
   privacyPolicyUrl?: string;
   howCapitalWorksUrl?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type FetchEphemeralKeyFunction = (fetchParams: {
 
 export type FinancingProductType = {
   productType: 'standard' | 'refill' | 'none';
+  activeFinancingCount: number;
 };
 
 export type FinancingPromotionLayoutType = 'full' | 'banner';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,10 +1454,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.3.22-preview-2":
-  version "3.3.22-preview-2"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.22-preview-2.tgz#0a2a260ebc32586f3290e56299a602ad198fc42f"
-  integrity sha512-KYHRwInYRXklXwQZmu3YVhN3xlpBscZw1Fyhgz1+Zs8uORYNkt2BJr09GQabR9PpEktLttv0HaILMS1aks0gOQ==
+"@stripe/connect-js@3.3.23-preview-1":
+  version "3.3.23-preview-1"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.23-preview-1.tgz#a4f2b4c67c0c193ac89e21bc054e412b76600174"
+  integrity sha512-0nMKInkK1UVFKEiq5fc1NJf11xfo76VRhCa+NHaxLLuJNwXa7jEL5hHaB6Y4FDNihOGUH7Mx9MEmi+96A2nsaw==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
Follow up to https://github.com/stripe/connect-js/pull/193

Adds a new field, `activeFinancingCount` to the data payload for the `setOnEligibleFinancingOfferLoaded` in the CapitalFinancingPromotion component so that platforms are able to selectively hide the component if the connected account has active financing.