### PR TITLE
Mark the use of attributes and events as deprecated (use setters instead)

### DIFF
--- a/src/utils/useAttachAttribute.ts
+++ b/src/utils/useAttachAttribute.ts
@@ -1,5 +1,9 @@
 import React from 'react';
 
+/**
+ * @deprecated The method should not be used as we are deprecating the use of attributes directly. 
+ * Define a setter for your use case and use useUpdateWithSetter instead.
+ */
 export const useAttachAttribute = (
   component: HTMLElement | null,
   attribute: string,

--- a/src/utils/useAttachEvent.ts
+++ b/src/utils/useAttachEvent.ts
@@ -6,6 +6,10 @@ export enum ConnectElementEventNames {
   instantPayoutCreated = 'instantpayoutcreated',
 }
 
+/**
+ * @deprecated The method should not be used as we are deprecating the use of events directly. Define a setter for
+ * your use case and use useUpdateWithSetter instead.
+ */
 export const useAttachEvent = (
   component: HTMLElement | null,
   eventName: ConnectElementEventNames,


### PR DESCRIPTION
These 2 methods should no longer be used. We should be using setters only. These are still used in a few instances unfortunately, so I am marking them as deprecated to avoid breaks.