### PR TITLE
Fix incorrect type definition for onTaxCodeSelect

### DIFF
--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -692,7 +692,7 @@ export const ConnectProductTaxCodeSelector = ({
   disabled,
   initialTaxCode
 }: {
-  onTaxCodeSelect?: ({taxCode}: {taxCode: string}) => void;
+  onTaxCodeSelect?: (taxCode: string) => void;
   hideDescription?: boolean;
   disabled?: boolean;
   initialTaxCode?: string;

--- a/src/utils/useUpdateWithSetter.ts
+++ b/src/utils/useUpdateWithSetter.ts
@@ -32,7 +32,7 @@ export const useUpdateWithSetter = <
     | ((StepChange: StepChange) => void)
     | Date
     | (({id}: {id: string}) => void)
-    | (({taxCode}: {taxCode: string}) => void)
+    | ((taxCode: string) => void)
     | undefined
 >(
   component: T | null,


### PR DESCRIPTION
The type of the `onTaxCodeSelect` prop was added incorrectly in https://github.com/stripe/react-connect-js/pull/146.

The approved type from API Review is `(taxCode: string) => void`.