### PR TITLE
Add a data attribute to npm wrapper divs so we can identify them from connect-js internally

### DIFF
--- a/src/useCreateComponent.tsx
+++ b/src/useCreateComponent.tsx
@@ -16,7 +16,7 @@ export const useCreateComponent = <T extends ConnectElementTagName>(
   const wrapperDivRef = React.useRef<HTMLDivElement | null>(null);
 
   // We would prefer to use display: contents, but it's not well-supported
-const wrapper = <div style={{width: '100%'}} data-stripe-connect-js-wrapper ref={wrapperDivRef}></div>;
+  const wrapper = <div style={{width: '100%'}} data-stripe-connect-js-wrapper ref={wrapperDivRef}></div>;
 
   React.useLayoutEffect(() => {
     if (wrapperDivRef.current !== null && component === null) {

--- a/src/useCreateComponent.tsx
+++ b/src/useCreateComponent.tsx
@@ -15,7 +15,9 @@ export const useCreateComponent = <T extends ConnectElementTagName>(
   const {connectInstance} = useConnectComponents();
   const wrapperDivRef = React.useRef<HTMLDivElement | null>(null);
 
-  // We would prefer to use display: contents, but it's not well-supported
+  // We set width to 100% to preserve this functionality aspect of embedded components even though
+  // we are introducing a wrapper div for this element
+  // https://docs.corp.stripe.com/connect/get-started-connect-embedded-components#width-and-height
   const wrapper = <div style={{width: '100%'}} data-stripe-connect-js-wrapper ref={wrapperDivRef}></div>;
 
   React.useLayoutEffect(() => {

--- a/src/useCreateComponent.tsx
+++ b/src/useCreateComponent.tsx
@@ -16,7 +16,7 @@ export const useCreateComponent = <T extends ConnectElementTagName>(
   const wrapperDivRef = React.useRef<HTMLDivElement | null>(null);
 
   // We would prefer to use display: contents, but it's not well-supported
-  const wrapper = <div style={{display: 'inline'}} ref={wrapperDivRef}></div>;
+const wrapper = <div style={{width: '100%'}} data-stripe-connect-js-wrapper ref={wrapperDivRef}></div>;
 
   React.useLayoutEffect(() => {
     if (wrapperDivRef.current !== null && component === null) {

--- a/src/useCreateComponent.tsx
+++ b/src/useCreateComponent.tsx
@@ -15,10 +15,8 @@ export const useCreateComponent = <T extends ConnectElementTagName>(
   const {connectInstance} = useConnectComponents();
   const wrapperDivRef = React.useRef<HTMLDivElement | null>(null);
 
-  // We set width to 100% to preserve this functionality aspect of embedded components even though
-  // we are introducing a wrapper div for this element
-  // https://docs.corp.stripe.com/connect/get-started-connect-embedded-components#width-and-height
-  const wrapper = <div style={{width: '100%'}} ref={wrapperDivRef}></div>;
+  // We would prefer to use display: contents, but it's not well-supported
+  const wrapper = <div style={{display: 'inline'}} ref={wrapperDivRef}></div>;
 
   React.useLayoutEffect(() => {
     if (wrapperDivRef.current !== null && component === null) {


### PR DESCRIPTION
This will let us determine the heights that flexible components should stretch to.