### PR TITLE
Add onApplicationStepChange to Capital Financing Application and Promotion Components

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.3.33-preview-1",
+    "@stripe/connect-js": "3.3.36-preview-1",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.3.33-preview-1",
+    "@stripe/connect-js": ">=3.3.36-preview-1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -584,12 +584,14 @@ export const ConnectCapitalFinancing = ({
 
 export const ConnectCapitalFinancingApplication = ({
   onApplicationSubmitted,
+  onApplicationStepChange,
   privacyPolicyUrl,
   howCapitalWorksUrl,
   onLoadError,
   onLoaderStart,
 }: {
   onApplicationSubmitted: () => void;
+  onApplicationStepChange?: ({step}: StepChange) => void;
   privacyPolicyUrl?: string;
   howCapitalWorksUrl?: string;
 } & CommonComponentProps): JSX.Element => {
@@ -602,6 +604,13 @@ export const ConnectCapitalFinancingApplication = ({
     onApplicationSubmitted,
     (comp, val) => comp.setOnApplicationSubmitted(val)
   );
+
+  useUpdateWithSetter(
+    capitalFinancingApplication,
+    onApplicationStepChange,
+    (comp, val) => comp.setOnApplicationStepChange(val)
+  );
+
   useUpdateWithSetter(
     capitalFinancingApplication,
     privacyPolicyUrl,
@@ -631,6 +640,7 @@ export const ConnectCapitalFinancingPromotion = ({
   layout,
   onApplicationSubmitted,
   onEligibleFinancingOfferLoaded,
+  onApplicationStepChange,
   privacyPolicyUrl,
   howCapitalWorksUrl,
   eligibilityCriteriaUrl,
@@ -646,6 +656,7 @@ export const ConnectCapitalFinancingPromotion = ({
   howCapitalWorksUrl?: string;
   eligibilityCriteriaUrl?: string;
   onApplicationSubmitted?: () => void;
+  onApplicationStepChange?: ({step}: StepChange) => void;
 } & CommonComponentProps): JSX.Element => {
   const {wrapper, component: capitalPromotion} = useCreateComponent(
     'capital-financing-promotion'
@@ -666,6 +677,9 @@ export const ConnectCapitalFinancingPromotion = ({
 
   useUpdateWithSetter(capitalPromotion, onApplicationSubmitted, (comp, val) =>
     comp.setOnApplicationSubmitted(val)
+  );
+  useUpdateWithSetter(capitalPromotion, onApplicationStepChange, (comp, val) =>
+    comp.setOnApplicationStepChange(val)
   );
 
   useUpdateWithSetter(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,10 +1510,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.3.33-preview-1":
-  version "3.3.33-preview-1"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.33-preview-1.tgz#4dc08f7e28eb9e23b7a046ef5c7f6e9c97cbaeb4"
-  integrity sha512-Gi7cGNEhw0ureIx8uProWmZ/NXrr8dxTX26Yg7iO2AB5tXV1mM8j0AFJAmz8vCscB5SyIMxi4sMElqz1s0TFUg==
+"@stripe/connect-js@3.3.36-preview-1":
+  version "3.3.36-preview-1"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.36-preview-1.tgz#fa5b2b721ff593600dfdbfca033d179d3c11d12c"
+  integrity sha512-yi3ze/TA5kPiAcwCnPnjPVpRMqqveIYYNHKKaun194GwB+DeIjDZoZSlv5LueOvyvo4IU6YhTMPxLii7kz9ILg==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
## Summary

- Bumps `@stripe/connect-js` version to `"3.3.36-preview-1"
- Adds `onApplicationStepChange` prop to `ConnectCapitalFinancingApplication` and `ConnectCapitalFinancingPromotion`


## Tests
Tested by rendering component and listening for event using local build:
<img width="553" height="73" alt="image" src="https://github.com/user-attachments/assets/5b376e62-8a5d-4959-9c26-66ddb1afa0a8" />

Result:

https://github.com/user-attachments/assets/9750b30e-d435-477f-bd2a-4c48f12234ff

