### PR TITLE
Add onAfterTaxRegistrationExpired

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.3.30",
+    "@stripe/connect-js": "3.3.31",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -413,9 +413,11 @@ export const ConnectTaxRegistrations = ({
   onLoaderStart,
   displayCountries,
   onAfterTaxRegistrationAdded,
+  onAfterTaxRegistrationExpired,
 }: {
   displayCountries?: string[];
   onAfterTaxRegistrationAdded?: ({id}: {id: string}) => void;
+  onAfterTaxRegistrationExpired?: ({id}: {id: string}) => void;
 } & CommonComponentProps): JSX.Element => {
   const {wrapper, component: taxRegistrations} =
     useCreateComponent('tax-registrations');
@@ -437,6 +439,14 @@ export const ConnectTaxRegistrations = ({
     onAfterTaxRegistrationAdded,
     (comp, val) => {
       comp.setOnAfterTaxRegistrationAdded(val);
+    }
+  );
+
+  useUpdateWithSetter(
+    taxRegistrations,
+    onAfterTaxRegistrationExpired,
+    (comp, val) => {
+      comp.setOnAfterTaxRegistrationExpired(val);
     }
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1577,10 +1577,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.3.30":
-  version "3.3.30"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.30.tgz#922b1d04a7af9f4dbf431a58ded152806b1c47fd"
-  integrity sha512-3GbRHNBqtmSvoAScTZYcXCaD8q+qf2Kpb6rb6+Rbc2kgKUykpoFuiHZKitW/DWC336z49XGZ/agJgYrEJ8r9vw==
+"@stripe/connect-js@3.3.31":
+  version "3.3.31"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.31.tgz#9c84e85aa15da4099b1dfb4807bf009663f1eee0"
+  integrity sha512-vjsZbatveSMoceOKZHt4eImmlBQla112OV9+enxcZUC1dGziTl2J2E3iH3n01yx9nu9ziesMJnSh/Y2d62TA/Q==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
This adds the `onAfterTaxRegistrationExpired` prop to the Tax Registrations embedded component, which has been approved by API Review.