### PR TITLE
Update onTaxCodeSelect

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.3.40-preview-1",
+    "@stripe/connect-js": "3.3.41-preview-1",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -723,7 +723,7 @@ export const ConnectProductTaxCodeSelector = ({
   disabled,
   initialTaxCode
 }: {
-  onTaxCodeSelect?: (taxCode: string, { analyticsName }: { analyticsName: string }) => void;
+  onTaxCodeSelect?: (taxCode: string | null, _: { analyticsName: string } | null) => void;
   hideDescription?: boolean;
   disabled?: boolean;
   initialTaxCode?: string;

--- a/src/utils/useUpdateWithSetter.ts
+++ b/src/utils/useUpdateWithSetter.ts
@@ -32,7 +32,7 @@ export const useUpdateWithSetter = <
     | ((StepChange: StepChange) => void)
     | Date
     | (({id}: {id: string}) => void)
-    | ((taxCode: string, {analyticsName}: {analyticsName: string}) => void)
+    | ((taxCode: string | null, _: {analyticsName: string} | null) => void)
     | (({promotionShown}: {promotionShown: boolean}) => void)
     | (({payoutId}: {payoutId: string}) => void)
     | undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,10 +1510,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.3.40-preview-1":
-  version "3.3.40-preview-1"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.40-preview-1.tgz#754c6a9637b98ebfb7921cf23b99e06d0ddc07f5"
-  integrity sha512-xYrv9fizMur3ijPxfkX+2975qbUaTlHnOyRhEp8u6SFl/hOMIgmbPKHPWgOx20WuPGJ2iRE0D+tK90wPUT8aug==
+"@stripe/connect-js@3.3.41-preview-1":
+  version "3.3.41-preview-1"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.41-preview-1.tgz#d1a83a900e3f5956426ae7aa787684edf3889a27"
+  integrity sha512-YppKDfXeHruc+Jvr9BDwqgWumQ0+VLXjTA61s+Pxuz+Z4v9ASrFVL+a0zkgOOuD+T/s8MoYgffHmY8LIH7YInw==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
This updates the signature of the `onTaxCodeSelect` prop, so `null` would get returned as a possible type for both positional arguments.

The change has been approved by an API Review addendum.