### PR TITLE
Add network-cost-passthrough-report embedded component to react-connect-js in preview branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.3.46-preview-1",
+    "@stripe/connect-js": "3.3.47-preview-1",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -90,7 +90,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.3.45-preview-1",
+    "@stripe/connect-js": ">=3.3.47-preview-1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -1037,3 +1037,20 @@ export const ConnectCheckScanning = ({
 
   return wrapper;
 };
+
+export const ConnectNetworkCostPassThroughReport = ({
+  onLoadError,
+  onLoaderStart,
+}: CommonComponentProps): JSX.Element => {
+  const {wrapper, component: networkCostPassThroughReport} =
+    useCreateComponent('network-cost-passthrough-report');
+
+  useUpdateWithSetter(networkCostPassThroughReport, onLoaderStart, (comp, val) => {
+    comp.setOnLoaderStart(val);
+  });
+  useUpdateWithSetter(networkCostPassThroughReport, onLoadError, (comp, val) => {
+    comp.setOnLoadError(val);
+  });
+
+  return wrapper;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,10 +1510,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.3.46-preview-1":
-  version "3.3.46-preview-1"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.46-preview-1.tgz#c475e81174934f4e67e7b597f46b4112ebf52ad9"
-  integrity sha512-eak1IyqP7/2ivvdESqJ+85E5UaOFhd+Aa54hzcZ49Cr99fJLhXxMJFmsS5c7sOghKEdVWRVpOap6iUdQcavH7g==
+"@stripe/connect-js@3.3.47-preview-1":
+  version "3.3.47-preview-1"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.47-preview-1.tgz#f65bcc44fe34910a25dc300097fd0ba94c63b693"
+  integrity sha512-9H/4AGamqpyjtPq23DwdScWKjBA9m28N8ZaO4xmYU5/5PdO40MKYvt/gdRSocCo7apu5bhGc1ZpqivoqR9Ij9A==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
Add network-cost-passthrough-report embedded component to react-connect-js in preview branch. Reference PR: https://github.com/stripe/react-connect-js/pull/146

This PR will be hold until the https://github.com/stripe/connect-js/pull/260 is merged. The package version of connect-js needs to be updated.