### PR TITLE
Publish new versions of SDK (post merging `preview` and `master`)

### DIFF
--- a/ga/package.json
+++ b/ga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/react-connect-js",
-  "version": "3.3.35",
+  "version": "3.3.36",
   "description": "React components for Connect.js and Connect embedded components",
   "main": "dist/react-connect.js",
   "module": "dist/react-connect.esm.js",
@@ -51,7 +51,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.3.38",
+    "@stripe/connect-js": "3.3.39",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -90,7 +90,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.3.38",
+    "@stripe/connect-js": ">=3.3.39",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/ga/yarn.lock
+++ b/ga/yarn.lock
@@ -1577,10 +1577,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.3.38":
-  version "3.3.38"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.38.tgz#e0945c7c375c62ae2cd980d83c7277e644772011"
-  integrity sha512-CnhJ8xzzUZD6/eHFDio/8Nea8U0tFicCkfWfP4x0VGq2JY8uS8t5O500NaHSajvQcPxQCrbG+/6xnM/8G9FLrA==
+"@stripe/connect-js@3.3.39":
+  version "3.3.39"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.39.tgz#7ca3b06064e164c3217ea295fd667bc05ac321b5"
+  integrity sha512-htv4fyTM2DHvlR5C48OslP7mrdwQ7uT1iMWjIy2924IhxA9oGuZsJoF7PIHn+fz/S1FKNhJm6i4yaUWqaj5t4A==
 
 "@tootallnate/once@2":
   version "2.0.0"

--- a/preview/package.json
+++ b/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/react-connect-js",
-  "version": "3.3.51-preview-1",
+  "version": "3.3.52-preview-1",
   "description": "React components for Connect.js and Connect embedded components",
   "main": "dist/react-connect.js",
   "module": "dist/react-connect.esm.js",
@@ -51,7 +51,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.3.53-preview-1",
+    "@stripe/connect-js": "3.3.54-preview-1",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -90,7 +90,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.3.53-preview-1",
+    "@stripe/connect-js": ">=3.3.54-preview-1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/preview/yarn.lock
+++ b/preview/yarn.lock
@@ -1510,10 +1510,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.3.53-preview-1":
-  version "3.3.53-preview-1"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.53-preview-1.tgz#daa4367800d401259a8df997d5db60a8a2bf1a1c"
-  integrity sha512-jefJ9ETx8eEV3DZtpkP+SBmWtAm/eSw/Ezc62Mqi6gRy+NCj9la5+1BHHPsbTHIGRBwsBmPmAr/2G+5JOi+ASg==
+"@stripe/connect-js@3.3.54-preview-1":
+  version "3.3.54-preview-1"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.3.54-preview-1.tgz#614755302698b3684675fd855111d51d4d4f927c"
+  integrity sha512-7gDO1DqV/DC0YrX5QrLTmfmWhVrTQhdn6zLEBm2tClAlqQ75KF6jDUjMPGmmdD+8dxLTs7V2f2ncSqDauFRRmA==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
Publish new versions of the SDK, after having merged `preview` and `master` in https://github.com/stripe/react-connect-js/pull/208