### PR TITLE
Bump `@stripe/connect-js`

### DIFF
--- a/ga/package.json
+++ b/ga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/react-connect-js",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "React components for Connect.js and Connect embedded components",
   "main": "dist/react-connect.js",
   "module": "dist/react-connect.esm.js",
@@ -51,7 +51,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.4.3",
+    "@stripe/connect-js": "3.4.5",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -90,7 +90,7 @@
     "zx": "^4.2.0"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.4.3",
+    "@stripe/connect-js": ">=3.4.5",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/ga/yarn.lock
+++ b/ga/yarn.lock
@@ -1685,10 +1685,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.4.3":
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.4.3.tgz#18713b661b7af2647003dcc575ef45b8276449c4"
-  integrity sha512-KeoOVpgWUaiCdylzPUDcra9XldevW6jsxTXNZAMm/wKRLpqyn4mz6xvZAY0gI8S527WzK6uyxVqSCXFJ7cSlMw==
+"@stripe/connect-js@3.4.5":
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.4.5.tgz#ed8ef5e7a6f89653cc865ecd1567d25cf4d4b795"
+  integrity sha512-2GZYc1pO2gYtq5rooZei483oSqeNROTD4XwnKXK8GXILvrLVJjMUCLDXi8Rmu8ojL5DWMnEOtXdnZxs8xxZecQ==
 
 "@tootallnate/once@2":
   version "2.0.0"

--- a/preview/package.json
+++ b/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/react-connect-js",
-  "version": "3.4.2-preview-2",
+  "version": "3.4.3-preview-1",
   "description": "React components for Connect.js and Connect embedded components",
   "main": "dist/react-connect.js",
   "module": "dist/react-connect.esm.js",
@@ -51,7 +51,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.4.3-preview-2",
+    "@stripe/connect-js": "3.4.4-preview-1",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -90,7 +90,7 @@
     "zx": "^8.8.5"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.4.3-preview-2",
+    "@stripe/connect-js": ">=3.4.4-preview-1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/preview/package.json
+++ b/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/react-connect-js",
-  "version": "3.4.2-preview-1",
+  "version": "3.4.2-preview-2",
   "description": "React components for Connect.js and Connect embedded components",
   "main": "dist/react-connect.js",
   "module": "dist/react-connect.esm.js",
@@ -51,7 +51,7 @@
     "@babel/preset-react": "7.18.6",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^2.3.1",
-    "@stripe/connect-js": "3.4.2-preview-1",
+    "@stripe/connect-js": "3.4.3-preview-2",
     "@types/jest": "^24.0.25",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
@@ -90,7 +90,7 @@
     "zx": "^8.8.5"
   },
   "peerDependencies": {
-    "@stripe/connect-js": ">=3.4.2-preview-1",
+    "@stripe/connect-js": ">=3.4.3-preview-2",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   }

--- a/preview/yarn.lock
+++ b/preview/yarn.lock
@@ -1625,10 +1625,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stripe/connect-js@3.4.2-preview-1":
-  version "3.4.2-preview-1"
-  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.4.2-preview-1.tgz#577d2ce3224ddad52a24da1389bf649e8929b04f"
-  integrity sha512-4VFAhtHx/NNNLmQcsBM8yGwdPWk8Xued0SfRYZoa6fIL15eaRagIGS1EjZTglssy5abX57zkf9/DLf6EyOnqTQ==
+"@stripe/connect-js@3.4.4-preview-1":
+  version "3.4.4-preview-1"
+  resolved "https://registry.yarnpkg.com/@stripe/connect-js/-/connect-js-3.4.4-preview-1.tgz#21e92d2a9665a3eb196fe98be0c3ec45a0463287"
+  integrity sha512-LGrc5HlAHUx8Ggz0JvNgzGdHv4IxeSujQmnpjYh3fpL8LPEHzgXV+a9X+5h/o9zW7dA7umgrTv6AwhcbPWEVMg==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
Take in a new version of the vanilla JS SDK. This mainly includes the new `displayOptions` parameter.