### PR TITLE
ci: add read-only token permissions to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: contents: read` to the test workflow. This restricts the GITHUB_TOKEN to the minimum scope needed (the workflow only checks out code and runs tests). Follows the principle of least privilege for Actions tokens.

For more info: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication