### PR TITLE
Add NPM release auto-publish workflow

### DIFF
--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -1,0 +1,108 @@
+name: NPM Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package to release'
+        required: true
+        type: choice
+        options:
+          - './ga'
+          - './preview'
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      connect_js_version:
+        description: 'Update @stripe/connect-js peer dep to this version (e.g. 3.4.6). Leave blank to keep current.'
+        required: false
+        type: string
+      dry_run:
+        description: 'Dry run (skip publish, push, and release)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  npm-release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.package }}
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn test
+      - run: yarn build
+
+      - name: Update connect-js peer dependency
+        if: ${{ inputs.connect_js_version != '' }}
+        run: |
+          node -e "
+            const pkg = require('./package.json');
+            pkg.peerDependencies['@stripe/connect-js'] = '>=${{ inputs.connect_js_version }}';
+            pkg.devDependencies['@stripe/connect-js'] = '${{ inputs.connect_js_version }}';
+            require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Bump version
+        id: version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            npm version ${{ inputs.version_bump }} --no-git-tag-version
+          else
+            npm version ${{ inputs.version_bump }} -m "Release %s (${{ inputs.package }})"
+          fi
+          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          echo "package_name=$(node -p "require('./package.json').name")" >> "$GITHUB_OUTPUT"
+
+      - name: Publish
+        if: ${{ !inputs.dry_run }}
+        run: |
+          if [ "${{ inputs.package }}" = "./preview" ]; then
+            npm publish --ignore-scripts --access public --tag preview
+          else
+            npm publish --ignore-scripts --access public
+          fi
+
+      - name: Push version commit and tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git push origin master --follow-tags
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry_run }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "v${{ steps.version.outputs.version }}"
+          name: "${{ steps.version.outputs.package_name }}@${{ steps.version.outputs.version }}"
+          generate_release_notes: true
+          prerelease: ${{ inputs.package == './preview' }}
+
+      - name: Notify Slack
+        if: always()
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_CONNECT_EMBEDDED }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ inputs.dry_run && '[DRY RUN] ' || '' }}${{ job.status == 'success' && '✅' || '❌' }} NPM Release: ${{ steps.version.outputs.package_name }}@${{ steps.version.outputs.version }} (${{ inputs.version_bump }}${{ inputs.connect_js_version != '' && format(', connect-js peer >={0}', inputs.connect_js_version) || '' }})\n${{ job.status == 'success' && 'Published successfully' || 'Release failed' }} • <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run> • Triggered by ${{ github.actor }}"
+            }


### PR DESCRIPTION
Does all the manual steps as we did before, then sends us a slack message. 