### PR TITLE
Add symlinks to sub-repo READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,7 @@ our [contributor guidelines](CONTRIBUTING.md).
 
 ## Preview/GA
 
-To work with the [preview](https://docs.stripe.com/connect/supported-embedded-components) version of embedded components, use the [/preview](/preview) folder. For the stable GA version, use [/ga](/ga).
+To work with the
+[preview](https://docs.stripe.com/connect/supported-embedded-components) version
+of embedded components, use the [/preview](/preview) folder. For the stable GA
+version, use [/ga](/ga).

--- a/ga/README.md
+++ b/ga/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/preview/README.md
+++ b/preview/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
Symlink ga/README.md and preview/README.md to the root README so that npm packages include the README on npmjs.com. Also fix missing trailing newline in README.md.

Same as https://github.com/stripe/connect-js/pull/311