### PR TITLE
Remove un-needed NPM_TOKEN token var

### DIFF
--- a/.github/workflows/npm_auto_release.yml
+++ b/.github/workflows/npm_auto_release.yml
@@ -71,11 +71,10 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build
+      - run: cp ../README.md .
 
       - name: Publish to npm
-        run: npm publish --ignore-scripts --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --ignore-scripts --access public
 
       - name: Generate scoped release notes
         id: notes
@@ -147,11 +146,10 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build
+      - run: cp ../README.md .
 
       - name: Publish to npm
-        run: npm publish --ignore-scripts --access public --tag preview
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --ignore-scripts --access public --tag preview
 
       - name: Generate scoped release notes
         id: notes

--- a/ga/README.md
+++ b/ga/README.md
@@ -1,1 +1,0 @@
-../README.md

--- a/preview/README.md
+++ b/preview/README.md
@@ -1,1 +1,0 @@
-../README.md


### PR DESCRIPTION
We actually use OIDC which means we just need to allow-list the workflow name, and not use a secret. Removing this for clarity.

Also, the symlink for the README wasn't working. Instead, have CI manually append the README in the future. 

Same as https://github.com/stripe/connect-js/pull/318 